### PR TITLE
Vs2010 project support

### DIFF
--- a/Capstone.NET-VS2010.sln
+++ b/Capstone.NET-VS2010.sln
@@ -1,0 +1,32 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gee.External.Capstone", "Gee.External.Capstone\Gee.External.Capstone-VS2010.csproj", "{1297DCEE-009D-4739-8124-3F064EA9EA10}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Gee.External.Capstone", "Tests.Gee.External.Capstone\Tests.Gee.External.Capstone-VS2010.csproj", "{7D755424-C594-4605-820D-9AF880E091BC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CapstoneCMD", "CapstoneCMD\CapstoneCMD-VS2010.csproj", "{D1A6EC03-1420-4516-8548-4117A18DA8B3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1297DCEE-009D-4739-8124-3F064EA9EA10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1297DCEE-009D-4739-8124-3F064EA9EA10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1297DCEE-009D-4739-8124-3F064EA9EA10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1297DCEE-009D-4739-8124-3F064EA9EA10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D755424-C594-4605-820D-9AF880E091BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D755424-C594-4605-820D-9AF880E091BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D755424-C594-4605-820D-9AF880E091BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D755424-C594-4605-820D-9AF880E091BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1A6EC03-1420-4516-8548-4117A18DA8B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1A6EC03-1420-4516-8548-4117A18DA8B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1A6EC03-1420-4516-8548-4117A18DA8B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1A6EC03-1420-4516-8548-4117A18DA8B3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/CapstoneCMD/CapstoneCMD-VS2010.csproj
+++ b/CapstoneCMD/CapstoneCMD-VS2010.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D1A6EC03-1420-4516-8548-4117A18DA8B3}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CapstoneCMD</RootNamespace>
+    <AssemblyName>CapstoneCMD</AssemblyName>
+    <TargetFrameworkVersion>v4.0.3</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>
+    </DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Gee.External.Capstone\Gee.External.Capstone.csproj">
+      <Project>{1297DCEE-009D-4739-8124-3F064EA9EA10}</Project>
+      <Name>Gee.External.Capstone</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Gee.External.Capstone/Gee.External.Capstone-VS2010.csproj
+++ b/Gee.External.Capstone/Gee.External.Capstone-VS2010.csproj
@@ -1,0 +1,186 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1297DCEE-009D-4739-8124-3F064EA9EA10}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Gee.External.Capstone</RootNamespace>
+    <AssemblyName>Gee.External.Capstone</AssemblyName>
+    <TargetFrameworkVersion>v4.0.3</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>
+    </DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>
+    </DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Gee.External.Capstone.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Arm64\Arm64AtInstructionOperation.cs" />
+    <Compile Include="Arm64\Arm64CodeCondition.cs" />
+    <Compile Include="Arm64\Arm64DcInstructionOperation.cs" />
+    <Compile Include="Arm64\Arm64IcInstructionOperation.cs" />
+    <Compile Include="Arm64\Arm64Instruction.cs" />
+    <Compile Include="Arm64\Arm64InstructionDetail.cs" />
+    <Compile Include="Arm64\Arm64InstructionGroup.cs" />
+    <Compile Include="Arm64\Arm64InstructionMemoryOperandValue.cs" />
+    <Compile Include="Arm64\Arm64InstructionOperand.cs" />
+    <Compile Include="Arm64\Arm64Extender.cs" />
+    <Compile Include="Arm64\Arm64MrsRegister.cs" />
+    <Compile Include="Arm64\Arm64MsrRegister.cs" />
+    <Compile Include="Arm64\Arm64Shifter.cs" />
+    <Compile Include="Arm64\Arm64ShifterType.cs" />
+    <Compile Include="Arm64\Arm64InstructionOperandType.cs" />
+    <Compile Include="Arm64\Arm64MemoryBarrierOperation.cs" />
+    <Compile Include="Arm64\Arm64PrefetchOperation.cs" />
+    <Compile Include="Arm64\Arm64PState.cs" />
+    <Compile Include="Arm64\Arm64Register.cs" />
+    <Compile Include="Arm64\Arm64TlbiInstructionOperation.cs" />
+    <Compile Include="Arm64\Arm64VectorArrangementSpecifier.cs" />
+    <Compile Include="Arm64\Arm64VectorElementSizeSpecifier.cs" />
+    <Compile Include="Arm64\CapstoneArm64Disassembler.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionDetailExtension.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionMemoryOperandValueExtension.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionOperandExtension.cs" />
+    <Compile Include="Arm64\NativeArm64ShifterExtension.cs" />
+    <Compile Include="Arm\ArmCodeCondition.cs" />
+    <Compile Include="Arm\ArmCpsFlag.cs" />
+    <Compile Include="Arm\ArmCpsMode.cs" />
+    <Compile Include="Arm\ArmInstruction.cs" />
+    <Compile Include="Arm\ArmInstructionGroup.cs" />
+    <Compile Include="Arm\ArmInstructionOperand.cs" />
+    <Compile Include="Arm\ArmInstructionOperandShiftType.cs" />
+    <Compile Include="Arm\ArmMemoryBarrier.cs" />
+    <Compile Include="Arm\ArmRegister.cs" />
+    <Compile Include="Arm\ArmSetEndInstructionOperandType.cs" />
+    <Compile Include="Arm\ArmVectorDataType.cs" />
+    <Compile Include="CapstoneDisassembler.cs" />
+    <Compile Include="CapstoneImport.cs" />
+    <Compile Include="CapstoneProxyImport.cs" />
+    <Compile Include="CapstoneX86Disassembler.cs" />
+    <Compile Include="DisassembleArchitecture.cs" />
+    <Compile Include="DisassembleErrorCode.cs" />
+    <Compile Include="DisassembleMode.cs" />
+    <Compile Include="DisassembleOptionType.cs" />
+    <Compile Include="DisassembleOptionValue.cs" />
+    <Compile Include="DisassembleSyntaxOptionValue.cs" />
+    <Compile Include="ExceptionThrower.cs" />
+    <Compile Include="IndependentInstructionGroup.cs" />
+    <Compile Include="Instruction.cs" />
+    <Compile Include="MarshalExtension.cs" />
+    <Compile Include="NativeArchitectureInstructionDetail.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionDetail.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionMemoryOperandValue.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionOperand.cs" />
+    <Compile Include="Arm64\NativeArm64Shifter.cs" />
+    <Compile Include="Arm64\NativeArm64InstructionOperandValue.cs" />
+    <Compile Include="Arm\NativeArmInstructionDetail.cs" />
+    <Compile Include="Arm\NativeArmInstructionMemoryOperandValue.cs" />
+    <Compile Include="Arm\NativeArmInstructionOperand.cs" />
+    <Compile Include="Arm\NativeArmInstructionOperandShift.cs" />
+    <Compile Include="Arm\NativeArmInstructionOperandValue.cs" />
+    <Compile Include="NativeCapstone.cs" />
+    <Compile Include="NativeIndependentInstructionDetailExtension.cs" />
+    <Compile Include="NativeInstruction.cs" />
+    <Compile Include="NativeIndependentInstructionDetail.cs" />
+    <Compile Include="NativeInstructionCollection.cs" />
+    <Compile Include="NativeInstructionCollectionEnumerator.cs" />
+    <Compile Include="NativeInstructionExtension.cs" />
+    <Compile Include="Mips\NativeMipsInstructionDetail.cs" />
+    <Compile Include="Mips\NativeMipsInstructionMemoryOperandValue.cs" />
+    <Compile Include="Mips\NativeMipsInstructionOperand.cs" />
+    <Compile Include="Mips\NativeMipsInstructionOperandValue.cs" />
+    <Compile Include="PowerPc\NativePowerPcInstructionConditionRegisterOperandValue.cs" />
+    <Compile Include="PowerPc\NativePowerPcInstructionDetail.cs" />
+    <Compile Include="PowerPc\NativePowerPcInstructionMemoryOperandValue.cs" />
+    <Compile Include="PowerPc\NativePowerPcInstructionOperand.cs" />
+    <Compile Include="PowerPc\NativePowerPcInstructionOperandValue.cs" />
+    <Compile Include="Sparc\NativeSparcInstructionDetail.cs" />
+    <Compile Include="Sparc\NativeSparcInstructionMemoryOperandValue.cs" />
+    <Compile Include="Sparc\NativeSparcInstructionOperand.cs" />
+    <Compile Include="Sparc\NativeSparcInstructionOperandValue.cs" />
+    <Compile Include="SystemZ\NativeSystemZInstructionDetail.cs" />
+    <Compile Include="SystemZ\NativeSystemZInstructionMemoryOperandValue.cs" />
+    <Compile Include="SystemZ\NativeSystemZInstructionOperand.cs" />
+    <Compile Include="SystemZ\NativeSystemZInstructionOperandValue.cs" />
+    <Compile Include="NativeX86InstructionDetailExtension.cs" />
+    <Compile Include="NativeX86InstructionMemoryOperandValue.cs" />
+    <Compile Include="NativeX86InstructionMemoryOperandValueExtension.cs" />
+    <Compile Include="NativeX86InstructionOperandExtension.cs" />
+    <Compile Include="NativeX86InstructionOperandValue.cs" />
+    <Compile Include="XCore\NativeXCoreInstructionDetail.cs" />
+    <Compile Include="XCore\NativeXCoreInstructionMemoryOperandValue.cs" />
+    <Compile Include="XCore\NativeXCoreInstructionOperand.cs" />
+    <Compile Include="XCore\NativeXCoreInstructionOperandValue.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SafeCapstoneHandle.cs" />
+    <Compile Include="NativeX86InstructionDetail.cs" />
+    <Compile Include="NativeX86InstructionOperand.cs" />
+    <Compile Include="SafeNativeInstructionHandle.cs" />
+    <Compile Include="X86AvxBroadcast.cs" />
+    <Compile Include="X86AvxCodeCondition.cs" />
+    <Compile Include="X86AvxRoundingMode.cs" />
+    <Compile Include="IndependentInstructionDetail.cs" />
+    <Compile Include="X86Instruction.cs" />
+    <Compile Include="X86InstructionDetail.cs" />
+    <Compile Include="X86InstructionGroup.cs" />
+    <Compile Include="X86InstructionMemoryOperandValue.cs" />
+    <Compile Include="X86InstructionOperand.cs" />
+    <Compile Include="X86InstructionOperandType.cs" />
+    <Compile Include="X86Prefix.cs" />
+    <Compile Include="X86Register.cs" />
+    <Compile Include="X86SseCodeCondition.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Tests.Gee.External.Capstone/Tests.Gee.External.Capstone-VS2010.csproj
+++ b/Tests.Gee.External.Capstone/Tests.Gee.External.Capstone-VS2010.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -9,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tests.Gee.External.Capstone</RootNamespace>
     <AssemblyName>Tests.Gee.External.Capstone</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0.3</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Tests.Gee.External.Capstone/Tests.Gee.External.Capstone-VS2010.csproj
+++ b/Tests.Gee.External.Capstone/Tests.Gee.External.Capstone-VS2010.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7D755424-C594-4605-820D-9AF880E091BC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tests.Gee.External.Capstone</RootNamespace>
+    <AssemblyName>Tests.Gee.External.Capstone</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestCapstoneArm64Disassembler.cs" />
+    <Compile Include="TestCapstoneX86Disassembler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Gee.External.Capstone\Gee.External.Capstone-VS2010.csproj">
+      <Project>{1297dcee-009d-4739-8124-3f064ea9ea10}</Project>
+      <Name>Gee.External.Capstone</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Tests.Gee.External.Capstone/Tests.Gee.External.Capstone-VS2010.csproj
+++ b/Tests.Gee.External.Capstone/Tests.Gee.External.Capstone-VS2010.csproj
@@ -63,7 +63,7 @@
     <Compile Include="TestCapstoneX86Disassembler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages-VS2010.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Gee.External.Capstone\Gee.External.Capstone-VS2010.csproj">

--- a/Tests.Gee.External.Capstone/packages-VS2010.config
+++ b/Tests.Gee.External.Capstone/packages-VS2010.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
I'm currently extending your C# binding for capstone. The aim is to reach a more extensive coverage of the Capstone native features as well as supporting the x64 version of the library. Due to some internal constraints I need to work with VS2010 which doesn't support .Net framework 4.5 out of the box and is caped to .Net framework 4.0.3.
This pull request handles this use case by providing a VS2010 specific solution file and 3 project files.
