### PR TITLE
Fixes for 2 memory-leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 **/obj
 packages/
 /*.suo
+/.vs/Capstone.NET/v15/Server/sqlite3/db.lock
+/.vs/Capstone.NET/v15/Server/sqlite3/storage.ide
+/.vs/Capstone.NET/v15/Server/sqlite3/storage.ide-shm
+/.vs/Capstone.NET/v15/Server/sqlite3/storage.ide-wal
+/.vs/Capstone.NET/v15/.suo

--- a/Gee.External.Capstone/CapstoneDisassembler.cs
+++ b/Gee.External.Capstone/CapstoneDisassembler.cs
@@ -225,13 +225,15 @@ namespace Gee.External.Capstone {
         ///     Thrown if the binary code could not be disassembled.
         /// </exception>
         public Instruction<TArchitectureInstruction, TArchitectureRegister, TArchitectureGroup, TArchitectureDetail>[] Disassemble(byte[] code, int count, long startingAddress) {
-            var nativeInstructions = NativeCapstone.Disassemble(this.Handle, code, count, startingAddress);
-            var instructions = nativeInstructions
-                .Instructions
-                .Select(this.CreateInstruction)
-                .ToArray();
+            using (var nativeInstructions = NativeCapstone.Disassemble(this.Handle, code, count, startingAddress))
+            {
+                var instructions = nativeInstructions
+                    .Instructions
+                    .Select(this.CreateInstruction)
+                    .ToArray();
 
-            return instructions;
+                return instructions;
+            }
         }
 
         /// <summary>

--- a/Gee.External.Capstone/CapstoneDisassembler.cs
+++ b/Gee.External.Capstone/CapstoneDisassembler.cs
@@ -549,6 +549,9 @@ namespace Gee.External.Capstone {
 
                 var iResultCode = (int) pResultCode;
                 var nativeInstructions = MarshalExtension.PtrToStructure<NativeInstruction>(pInstructions, iResultCode);
+
+                Marshal.FreeHGlobal(pInstructions);
+
                 if (nativeInstructions == null || nativeInstructions.Length == 0) {
                     return false;
                 }


### PR DESCRIPTION
Hi 9ee1. Thanks for creating this project. I'm using it in a new project, which I will push to Github soon. While using your project I found 2 memory-leaks. I fixed them in my fork. Feel free to pull them to your branch.

The first memory-leak happens in CapstoneDisassembler.Disassemble() because the ownership of an disposable object is passed to this function. The object should then be disposed in this function.

The second memory-leak happens in CapstoneDisassembler.MoveNext(). It gets unmanaged data, which needs to be freed.