### PR TITLE
Use Generic Marshal Methods

### DIFF
--- a/Gee.External.Capstone/MarshalExtension.cs
+++ b/Gee.External.Capstone/MarshalExtension.cs
@@ -17,7 +17,7 @@ internal static class MarshalExtension {
     ///     A pointer to the allocated memory.
     /// </returns>
     internal static IntPtr AllocHGlobal<T>() {
-        var nType = MarshalExtension.SizeOf<T>();
+        var nType = Marshal.SizeOf<T>();
         var pType = Marshal.AllocHGlobal(nType);
 
         return pType;
@@ -36,7 +36,7 @@ internal static class MarshalExtension {
     ///     A pointer to the allocated memory.
     /// </returns>
     internal static IntPtr AllocHGlobal<T>(int size) {
-        var nType = MarshalExtension.SizeOf<T>() * size;
+        var nType = Marshal.SizeOf<T>() * size;
         var pType = Marshal.AllocHGlobal(nType);
 
         return pType;
@@ -55,27 +55,10 @@ internal static class MarshalExtension {
     ///     The destination structure.
     /// </returns>
     internal static T FreePtrToStructure<T>(IntPtr p) {
-        var @struct = Marshal.PtrToStructure(p, typeof(T));
+        var @struct = Marshal.PtrToStructure<T>(p);
         Marshal.FreeHGlobal(p);
 
-        return (T)@struct;
-    }
-
-    /// <summary>
-    ///     Marshal a Pointer to a Structure.
-    /// </summary>
-    /// <typeparam name="T">
-    ///     The destination structure's type.
-    /// </typeparam>
-    /// <param name="p">
-    ///     The pointer to marshal.
-    /// </param>
-    /// <returns>
-    ///     The destination structure.
-    /// </returns>
-    internal static T PtrToStructure<T>(IntPtr p) {
-        var @struct = Marshal.PtrToStructure(p, typeof(T));
-        return (T)@struct;
+        return @struct;
     }
 
     /// <summary>
@@ -97,26 +80,12 @@ internal static class MarshalExtension {
         var array = new T[size];
         var index = p;
         for (var i = 0; i < size; i++) {
-            var element = MarshalExtension.PtrToStructure<T>(index);
+            var element = Marshal.PtrToStructure<T>(index);
             array[i] = element;
 
-            index += Marshal.SizeOf(typeof(T));
+            index += Marshal.SizeOf<T>();
         }
 
         return array;
-    }
-
-    /// <summary>
-    ///     Get a Type's Size.
-    /// </summary>
-    /// <typeparam name="T">
-    ///     The type.
-    /// </typeparam>
-    /// <returns>
-    ///     The type's size, in bytes.
-    /// </returns>
-    internal static int SizeOf<T>() {
-        var size = Marshal.SizeOf(typeof(T));
-        return size;
     }
 }

--- a/Gee.External.Capstone/NativeCapstone.cs
+++ b/Gee.External.Capstone/NativeCapstone.cs
@@ -228,7 +228,7 @@ internal static class NativeCapstone {
             // ...
             //
             // Throws an exception if the operation fails.
-            var instruction = MarshalExtension.PtrToStructure<NativeInstruction>(pInstruction);
+            var instruction = Marshal.PtrToStructure<NativeInstruction>(pInstruction);
             return instruction;
         }
         finally {
@@ -254,7 +254,7 @@ internal static class NativeCapstone {
             // First, we calculate the memory address of the <c>NativeInstruction.Details</c> field, which is
             // always relative to the memory address of its defining <c>NativeInstruction</c> structure. This is
             // NOT the actual memory address of the instruction's details.
-            var instructionDetailOffset = Marshal.OffsetOf(typeof(NativeInstruction), nameof(NativeInstruction.Details));
+            var instructionDetailOffset = Marshal.OffsetOf<NativeInstruction>(nameof(NativeInstruction.Details));
             var pInstructionDetail = (IntPtr)((long)pInstruction + (long)instructionDetailOffset);
 
             // ...
@@ -265,7 +265,7 @@ internal static class NativeCapstone {
             var ppInstructionDetail = Marshal.ReadIntPtr(pInstructionDetail);
             NativeInstructionDetail? instructionDetail = null;
             if (ppInstructionDetail != IntPtr.Zero) {
-                instructionDetail = MarshalExtension.PtrToStructure<NativeInstructionDetail>(ppInstructionDetail);
+                instructionDetail = Marshal.PtrToStructure<NativeInstructionDetail>(ppInstructionDetail);
             }
 
             return instructionDetail;
@@ -296,7 +296,7 @@ internal static class NativeCapstone {
             // First, we calculate the memory address of the <c>NativeInstruction.Details</c> field, which is
             // always relative to the memory address of its defining <c>NativeInstruction</c> structure. This is
             // NOT the actual memory address of the instruction's details.
-            var instructionDetailOffset = Marshal.OffsetOf(typeof(NativeInstruction), nameof(NativeInstruction.Details));
+            var instructionDetailOffset = Marshal.OffsetOf<NativeInstruction>(nameof(NativeInstruction.Details));
             var pInstructionDetail = (IntPtr)((long)pInstruction + (long)instructionDetailOffset);
 
             // ...
@@ -312,7 +312,7 @@ internal static class NativeCapstone {
                 // Fourth, we calculate the memory address of the instruction's architecture specific details,
                 // which is always relative to the memory address of the instruction's details.
                 var pArchInstructionDetail = ppInstructionDetail + NativeCapstone.MagicInstructionArchitectureDetailsFieldOffset;
-                instructionDetail = (TInstructionDetail)Marshal.PtrToStructure(pArchInstructionDetail, typeof(TInstructionDetail));
+                instructionDetail = Marshal.PtrToStructure<TInstructionDetail>(pArchInstructionDetail);
             }
 
             return instructionDetail;
@@ -339,7 +339,7 @@ internal static class NativeCapstone {
             //
             // Throws an exception if the operation fails.
             var pInstructionDetails = instruction.Details;
-            instructionDetails = MarshalExtension.PtrToStructure<NativeInstructionDetail>(pInstructionDetails);
+            instructionDetails = Marshal.PtrToStructure<NativeInstructionDetail>(pInstructionDetails);
         }
 
         return instructionDetails;
@@ -365,7 +365,7 @@ internal static class NativeCapstone {
             //
             // Throws an exception if the operation fails.
             var pInstructionDetails = instruction.Details + NativeCapstone.MagicInstructionArchitectureDetailsFieldOffset;
-            instructionDetails = MarshalExtension.PtrToStructure<TInstructionDetails>(pInstructionDetails);
+            instructionDetails = Marshal.PtrToStructure<TInstructionDetails>(pInstructionDetails);
         }
 
         return instructionDetails;


### PR DESCRIPTION
This pull request replaces non-generic Marshal methods with their generic variants. The non-generic ones were causing problems with trimming for NativeAOT. I also removed two obsolete polyfills left over from when Capstone supported .NET Framework.